### PR TITLE
Login screen page

### DIFF
--- a/CMPUT_301_Project/app/src/main/AndroidManifest.xml
+++ b/CMPUT_301_Project/app/src/main/AndroidManifest.xml
@@ -10,6 +10,9 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.CMPUT_301_Project">
         <activity
+            android:name=".LoginScreenPage"
+            android:exported="true" />
+        <activity
             android:name=".LoginTestPage"
             android:exported="true">
             <intent-filter>
@@ -20,12 +23,10 @@
         </activity>
         <activity
             android:name=".TodayHabits"
-            android:label="@string/app_name">
-        </activity>
+            android:label="@string/app_name" />
         <activity
             android:name=".AccountSettings"
-            android:label="@string/app_name">
-        </activity>
+            android:label="@string/app_name" />
     </application>
 
 </manifest>

--- a/CMPUT_301_Project/app/src/main/java/com/example/cmput_301_project/LoginScreenPage.java
+++ b/CMPUT_301_Project/app/src/main/java/com/example/cmput_301_project/LoginScreenPage.java
@@ -1,0 +1,33 @@
+package com.example.cmput_301_project;
+
+import static androidx.core.content.ContextCompat.getSystemService;
+
+import android.content.Context;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+
+import android.view.KeyEvent;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+public class LoginScreenPage extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_login_screen_page);
+    }
+}

--- a/CMPUT_301_Project/app/src/main/java/com/example/cmput_301_project/LoginScreenPage.java
+++ b/CMPUT_301_Project/app/src/main/java/com/example/cmput_301_project/LoginScreenPage.java
@@ -3,6 +3,7 @@ package com.example.cmput_301_project;
 import static androidx.core.content.ContextCompat.getSystemService;
 
 import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
@@ -42,10 +43,14 @@ public class LoginScreenPage extends AppCompatActivity {
         transaction = manager.beginTransaction();
         transaction.add(R.id.signUpLayout, registerFragment);
         transaction.addToBackStack(null);
+        // execute transaction and open sign-up fragment
         transaction.commit();
     }
 
     public void onSignInClick(View view) {
-        // TODO: add functionality to check user credentials & redirect to main page here
+        // TODO: add functionality to check user credentials
+        // when 'sign in' button is pressed, open the temporary main page
+        Intent switchToMainPage = new Intent(LoginScreenPage.this, LoginTestPage.class);
+        startActivity(switchToMainPage);
     }
 }

--- a/CMPUT_301_Project/app/src/main/java/com/example/cmput_301_project/LoginScreenPage.java
+++ b/CMPUT_301_Project/app/src/main/java/com/example/cmput_301_project/LoginScreenPage.java
@@ -44,4 +44,8 @@ public class LoginScreenPage extends AppCompatActivity {
         transaction.addToBackStack(null);
         transaction.commit();
     }
+
+    public void onSignInClick(View view) {
+        // TODO: add functionality to check user credentials & redirect to main page here
+    }
 }

--- a/CMPUT_301_Project/app/src/main/java/com/example/cmput_301_project/LoginScreenPage.java
+++ b/CMPUT_301_Project/app/src/main/java/com/example/cmput_301_project/LoginScreenPage.java
@@ -10,6 +10,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentTransaction;
 
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -25,9 +26,22 @@ import android.widget.Toast;
 
 public class LoginScreenPage extends AppCompatActivity {
 
+    FragmentManager manager = getSupportFragmentManager();
+    FragmentTransaction transaction;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_login_screen_page);
+    }
+
+    public void onRegisterClick(View view) {
+        // create a new settings fragment and display it on the appropriate frame
+        Fragment registerFragment = new SignUpFragment();
+        //begin fragment transaction and add current activity to backstack
+        transaction = manager.beginTransaction();
+        transaction.add(R.id.signUpLayout, registerFragment);
+        transaction.addToBackStack(null);
+        transaction.commit();
     }
 }

--- a/CMPUT_301_Project/app/src/main/java/com/example/cmput_301_project/LoginTestPage.java
+++ b/CMPUT_301_Project/app/src/main/java/com/example/cmput_301_project/LoginTestPage.java
@@ -84,6 +84,16 @@ public class LoginTestPage extends AppCompatActivity {
             }
         });
 
+        // functionality for loginButton to go to LoginScreenPage
+        final Button loginScreenButton = findViewById(R.id.loginButton);
+        loginScreenButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                Intent switchActivityIntent = new Intent(LoginTestPage.this, LoginScreenPage.class);
+                startActivity(switchActivityIntent);
+            }
+        });
+
         addButton.setOnClickListener( new View.OnClickListener() {
             @Override
             public void onClick(View view) {

--- a/CMPUT_301_Project/app/src/main/java/com/example/cmput_301_project/SignUpFragment.java
+++ b/CMPUT_301_Project/app/src/main/java/com/example/cmput_301_project/SignUpFragment.java
@@ -71,6 +71,7 @@ public class SignUpFragment extends Fragment  implements View.OnClickListener {
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
         View view = inflater.inflate(R.layout.fragment_sign_up, container, false);
+        // add buttons for sign-up and exit and set their onClick listeners to current class
         Button signUpButton = (Button) view.findViewById(R.id.signUpButton);
         Button exitButton = (Button) view.findViewById(R.id.cancelButton);
         signUpButton.setOnClickListener(this);
@@ -81,12 +82,14 @@ public class SignUpFragment extends Fragment  implements View.OnClickListener {
 
     @Override
     public void onClick(View view) {
+        // override onClick depending on if the 'sign-up' or 'cancel' button is pressed
         switch(view.getId()) {
             case R.id.signUpButton:
                 // TODO: add code to create a new user account here
                 getActivity().onBackPressed();
                 break;
             case R.id.cancelButton:
+                // if the cancel button is pressed, close the fragment and return to login page
                 getActivity().onBackPressed();
                 break;
         }

--- a/CMPUT_301_Project/app/src/main/java/com/example/cmput_301_project/SignUpFragment.java
+++ b/CMPUT_301_Project/app/src/main/java/com/example/cmput_301_project/SignUpFragment.java
@@ -1,0 +1,78 @@
+package com.example.cmput_301_project;
+
+import static androidx.core.content.ContextCompat.getSystemService;
+
+import android.content.Context;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+
+import android.view.KeyEvent;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+/**
+ * A simple {@link Fragment} subclass.
+ * Use the {@link SignUpFragment#newInstance} factory method to
+ * create an instance of this fragment.
+ */
+public class SignUpFragment extends Fragment {
+
+    // TODO: Rename parameter arguments, choose names that match
+    // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+    private static final String ARG_PARAM1 = "param1";
+    private static final String ARG_PARAM2 = "param2";
+
+    // TODO: Rename and change types of parameters
+    private String mParam1;
+    private String mParam2;
+
+    public SignUpFragment() {
+        // Required empty public constructor
+    }
+
+    /**
+     * Use this factory method to create a new instance of
+     * this fragment using the provided parameters.
+     *
+     * @param param1 Parameter 1.
+     * @param param2 Parameter 2.
+     * @return A new instance of fragment SignUpFragment.
+     */
+    // TODO: Rename and change types and number of parameters
+    public static SignUpFragment newInstance(String param1, String param2) {
+        SignUpFragment fragment = new SignUpFragment();
+        Bundle args = new Bundle();
+        args.putString(ARG_PARAM1, param1);
+        args.putString(ARG_PARAM2, param2);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            mParam1 = getArguments().getString(ARG_PARAM1);
+            mParam2 = getArguments().getString(ARG_PARAM2);
+        }
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_sign_up, container, false);
+    }
+}

--- a/CMPUT_301_Project/app/src/main/java/com/example/cmput_301_project/SignUpFragment.java
+++ b/CMPUT_301_Project/app/src/main/java/com/example/cmput_301_project/SignUpFragment.java
@@ -29,13 +29,6 @@ import android.widget.Toast;
  */
 public class SignUpFragment extends Fragment  implements View.OnClickListener {
 
-    // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-    private static final String ARG_PARAM1 = "param1";
-    private static final String ARG_PARAM2 = "param2";
-
-    private String mParam1;
-    private String mParam2;
-
     public SignUpFragment() {
         // Required empty public constructor
     }
@@ -43,16 +36,11 @@ public class SignUpFragment extends Fragment  implements View.OnClickListener {
     /**
      * Use this factory method to create a new instance of
      * this fragment using the provided parameters.
-     *
-     * @param param1 Parameter 1.
-     * @param param2 Parameter 2.
      * @return A new instance of fragment SignUpFragment.
      */
     public static SignUpFragment newInstance(String param1, String param2) {
         SignUpFragment fragment = new SignUpFragment();
         Bundle args = new Bundle();
-        args.putString(ARG_PARAM1, param1);
-        args.putString(ARG_PARAM2, param2);
         fragment.setArguments(args);
         return fragment;
     }
@@ -60,10 +48,6 @@ public class SignUpFragment extends Fragment  implements View.OnClickListener {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (getArguments() != null) {
-            mParam1 = getArguments().getString(ARG_PARAM1);
-            mParam2 = getArguments().getString(ARG_PARAM2);
-        }
     }
 
     @Override

--- a/CMPUT_301_Project/app/src/main/java/com/example/cmput_301_project/SignUpFragment.java
+++ b/CMPUT_301_Project/app/src/main/java/com/example/cmput_301_project/SignUpFragment.java
@@ -27,14 +27,12 @@ import android.widget.Toast;
  * Use the {@link SignUpFragment#newInstance} factory method to
  * create an instance of this fragment.
  */
-public class SignUpFragment extends Fragment {
+public class SignUpFragment extends Fragment  implements View.OnClickListener {
 
-    // TODO: Rename parameter arguments, choose names that match
     // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
     private static final String ARG_PARAM1 = "param1";
     private static final String ARG_PARAM2 = "param2";
 
-    // TODO: Rename and change types of parameters
     private String mParam1;
     private String mParam2;
 
@@ -50,7 +48,6 @@ public class SignUpFragment extends Fragment {
      * @param param2 Parameter 2.
      * @return A new instance of fragment SignUpFragment.
      */
-    // TODO: Rename and change types and number of parameters
     public static SignUpFragment newInstance(String param1, String param2) {
         SignUpFragment fragment = new SignUpFragment();
         Bundle args = new Bundle();
@@ -73,6 +70,25 @@ public class SignUpFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_sign_up, container, false);
+        View view = inflater.inflate(R.layout.fragment_sign_up, container, false);
+        Button signUpButton = (Button) view.findViewById(R.id.signUpButton);
+        Button exitButton = (Button) view.findViewById(R.id.cancelButton);
+        signUpButton.setOnClickListener(this);
+        exitButton.setOnClickListener(this);
+
+        return view;
+    }
+
+    @Override
+    public void onClick(View view) {
+        switch(view.getId()) {
+            case R.id.signUpButton:
+                // TODO: add code to create a new user account here
+                getActivity().onBackPressed();
+                break;
+            case R.id.cancelButton:
+                getActivity().onBackPressed();
+                break;
+        }
     }
 }

--- a/CMPUT_301_Project/app/src/main/res/layout/activity_login_screen_page.xml
+++ b/CMPUT_301_Project/app/src/main/res/layout/activity_login_screen_page.xml
@@ -17,7 +17,7 @@
         android:layout_marginTop="48dp"
         android:layout_marginEnd="80dp"
         android:layout_marginBottom="48dp"
-        app:layout_constraintBottom_toTopOf="@+id/linearLayout"
+        app:layout_constraintBottom_toTopOf="@+id/signinPromptsVLL"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.516"
         app:layout_constraintStart_toStartOf="parent"
@@ -25,18 +25,19 @@
         app:srcCompat="@drawable/circle_green" />
 
     <LinearLayout
-        android:id="@+id/linearLayout"
+        android:id="@+id/signinPromptsVLL"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
         android:orientation="vertical"
-        app:layout_constraintBottom_toTopOf="@+id/linearLayout3"
+        app:layout_constraintBottom_toTopOf="@+id/activityNavButtonsHLL"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/logoImage">
 
         <LinearLayout
+            android:id="@+id/enterUsernameHLL"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal">
@@ -59,6 +60,7 @@
         </LinearLayout>
 
         <LinearLayout
+            android:id="@+id/enterPasswordHLL"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
@@ -83,7 +85,7 @@
         </LinearLayout>
 
         <TextView
-            android:id="@+id/textView3"
+            android:id="@+id/registerPromptTV"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingTop="24dp"
@@ -94,7 +96,7 @@
     </LinearLayout>
 
     <LinearLayout
-        android:id="@+id/linearLayout3"
+        android:id="@+id/activityNavButtonsHLL"
         android:layout_width="416dp"
         android:layout_height="70dp"
         android:orientation="horizontal"

--- a/CMPUT_301_Project/app/src/main/res/layout/activity_login_screen_page.xml
+++ b/CMPUT_301_Project/app/src/main/res/layout/activity_login_screen_page.xml
@@ -8,6 +8,7 @@
     tools:context=".LoginScreenPage">
 
     <!-- TODO: replace placeholder drawable with actual logo -->
+
     <ImageView
         android:id="@+id/logoImage"
         android:layout_width="237dp"
@@ -118,8 +119,15 @@
             android:layout_height="fill_parent"
             android:layout_weight="1"
             android:backgroundTint="@color/white"
-            android:textColor="@color/black"
-            android:text="Register" />
+            android:onClick="onRegisterClick"
+            android:text="Register"
+            android:textColor="@color/black" />
     </LinearLayout>
+
+    <FrameLayout
+        android:id="@+id/signUpLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" >
+    </FrameLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/CMPUT_301_Project/app/src/main/res/layout/activity_login_screen_page.xml
+++ b/CMPUT_301_Project/app/src/main/res/layout/activity_login_screen_page.xml
@@ -102,7 +102,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent">
 
-        <!-- TODO: signIn Button should redirect to main page pending account validation completion -->
         <Button
             android:id="@+id/signInButton"
             android:layout_width="0dp"

--- a/CMPUT_301_Project/app/src/main/res/layout/activity_login_screen_page.xml
+++ b/CMPUT_301_Project/app/src/main/res/layout/activity_login_screen_page.xml
@@ -109,10 +109,10 @@
             android:layout_height="fill_parent"
             android:layout_weight="1"
             android:backgroundTint="@color/black"
+            android:onClick="onSignInClick"
             android:text="Sign In" />
 
 
-        <!-- TODO: register button should redirect to account creation fragment -->
         <Button
             android:id="@+id/registerButton"
             android:layout_width="0dp"

--- a/CMPUT_301_Project/app/src/main/res/layout/activity_login_screen_page.xml
+++ b/CMPUT_301_Project/app/src/main/res/layout/activity_login_screen_page.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:exported="true"
+    tools:context=".LoginScreenPage">
+
+    <!-- TODO: replace placeholder drawable with actual logo -->
+    <ImageView
+        android:id="@+id/logoImage"
+        android:layout_width="237dp"
+        android:layout_height="237dp"
+        android:layout_marginStart="80dp"
+        android:layout_marginTop="48dp"
+        android:layout_marginEnd="80dp"
+        android:layout_marginBottom="48dp"
+        app:layout_constraintBottom_toTopOf="@+id/linearLayout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.516"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/circle_green" />
+
+    <LinearLayout
+        android:id="@+id/linearLayout"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toTopOf="@+id/linearLayout3"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/logoImage">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/usernameTV"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Username:"
+                android:textSize="24sp" />
+
+            <EditText
+                android:id="@+id/usernameEV"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_weight="2"
+                android:ems="10"
+                android:inputType="textPersonName" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingTop="32dp">
+
+            <TextView
+                android:id="@+id/passwordTV"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="2"
+                android:text="Password:"
+                android:textSize="24sp" />
+
+            <EditText
+                android:id="@+id/passwordEV"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:layout_weight="1"
+                android:ems="10"
+                android:inputType="textPassword" />
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/textView3"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="24dp"
+            android:text="Don't have an account yet? Register!"
+            android:textAlignment="center"
+            android:textColor="#000000" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/linearLayout3"
+        android:layout_width="416dp"
+        android:layout_height="70dp"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <!-- TODO: signIn Button should redirect to main page pending account validation completion -->
+        <Button
+            android:id="@+id/signInButton"
+            android:layout_width="0dp"
+            android:layout_height="fill_parent"
+            android:layout_weight="1"
+            android:backgroundTint="@color/black"
+            android:text="Sign In" />
+
+
+        <!-- TODO: register button should redirect to account creation fragment -->
+        <Button
+            android:id="@+id/registerButton"
+            android:layout_width="0dp"
+            android:layout_height="fill_parent"
+            android:layout_weight="1"
+            android:backgroundTint="@color/white"
+            android:textColor="@color/black"
+            android:text="Register" />
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/CMPUT_301_Project/app/src/main/res/layout/fragment_sign_up.xml
+++ b/CMPUT_301_Project/app/src/main/res/layout/fragment_sign_up.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/registerLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white"
+    tools:context=".SignUpFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/createAccountTV"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:text="Create a New Account"
+            android:textAlignment="center"
+            android:textSize="32sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="64dp"
+            android:layout_marginEnd="16dp"
+            android:orientation="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/createAccountTV">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/createEmailTV"
+                    android:layout_width="0dp"
+                    android:layout_height="fill_parent"
+                    android:layout_weight="1"
+                    android:text="Email:"
+                    android:textSize="24sp" />
+
+                <EditText
+                    android:id="@+id/createEmailEV"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="2"
+                    android:ems="10"
+                    android:inputType="textPersonName" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginTop="32dp"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/createUsernameTV"
+                    android:layout_width="wrap_content"
+                    android:layout_height="fill_parent"
+                    android:layout_weight="1"
+                    android:text="Username:"
+                    android:textSize="24sp" />
+
+                <EditText
+                    android:id="@+id/createUsernameEV"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="4"
+                    android:ems="10"
+                    android:inputType="textPersonName" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginTop="32dp"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/createPasswordTV"
+                    android:layout_width="wrap_content"
+                    android:layout_height="fill_parent"
+                    android:layout_weight="1"
+                    android:text="Password:"
+                    android:textSize="24sp" />
+
+                <EditText
+                    android:id="@+id/createPasswordEV"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="4"
+                    android:ems="10"
+                    android:inputType="textPassword" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginTop="32dp"
+                android:orientation="horizontal">
+
+                <!-- TODO: needs to be in line with other field TV's -->
+                <TextView
+                    android:id="@+id/reenterPasswordTV"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:lines="2"
+                    android:text="Re-Enter Password:"
+                    android:textSize="24sp" />
+
+                <EditText
+                    android:id="@+id/reenterPasswordEV"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="30"
+                    android:ems="10"
+                    android:inputType="textPassword" />
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/linearLayout2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <!-- TODO: both buttons need functionality (skeleton func. = return to login page -->
+            <Button
+                android:id="@+id/signUpButton"
+                android:layout_width="wrap_content"
+                android:layout_height="64dp"
+                android:layout_weight="1"
+                android:backgroundTint="@color/black"
+                android:text="Sign Up" />
+
+            <Button
+                android:id="@+id/cancelButton"
+                android:layout_width="wrap_content"
+                android:layout_height="64dp"
+                android:layout_weight="1"
+                android:backgroundTint="@color/white"
+                android:text="Cancel"
+                android:textColor="@color/black" />
+        </LinearLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</FrameLayout>

--- a/CMPUT_301_Project/app/src/main/res/layout/fragment_sign_up.xml
+++ b/CMPUT_301_Project/app/src/main/res/layout/fragment_sign_up.xml
@@ -25,6 +25,7 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <LinearLayout
+            android:id="@+id/pinputPromptsVLL"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
@@ -36,6 +37,7 @@
             app:layout_constraintTop_toBottomOf="@+id/createAccountTV">
 
             <LinearLayout
+                android:id="@+id/createEmailHLL"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal">
@@ -46,7 +48,7 @@
                     android:layout_height="fill_parent"
                     android:layout_weight="1"
                     android:text="Email:"
-                    android:textSize="24sp" />
+                    android:textSize="20sp" />
 
                 <EditText
                     android:id="@+id/createEmailEV"
@@ -58,6 +60,7 @@
             </LinearLayout>
 
             <LinearLayout
+                android:id="@+id/createUsernameHLL"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_marginTop="32dp"
@@ -69,18 +72,19 @@
                     android:layout_height="fill_parent"
                     android:layout_weight="1"
                     android:text="Username:"
-                    android:textSize="24sp" />
+                    android:textSize="20sp" />
 
                 <EditText
                     android:id="@+id/createUsernameEV"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="4"
+                    android:layout_weight="1.5"
                     android:ems="10"
                     android:inputType="textPersonName" />
             </LinearLayout>
 
             <LinearLayout
+                android:id="@+id/createPasswordHLL"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_marginTop="32dp"
@@ -92,18 +96,19 @@
                     android:layout_height="fill_parent"
                     android:layout_weight="1"
                     android:text="Password:"
-                    android:textSize="24sp" />
+                    android:textSize="20sp" />
 
                 <EditText
                     android:id="@+id/createPasswordEV"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="4"
+                    android:layout_weight="1.5"
                     android:ems="10"
                     android:inputType="textPassword" />
             </LinearLayout>
 
             <LinearLayout
+                android:id="@+id/reenterPasswordHLL"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_marginTop="32dp"
@@ -115,14 +120,15 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:lines="2"
-                    android:text="Re-Enter Password:"
-                    android:textSize="14sp" />
+                    android:paddingBottom="20dp"
+                    android:text="Re-Enter \nPassword:"
+                    android:textSize="20sp" />
 
                 <EditText
                     android:id="@+id/reenterPasswordEV"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="32"
+                    android:layout_weight="1.5"
                     android:ems="10"
                     android:inputType="textPassword" />
             </LinearLayout>
@@ -130,7 +136,7 @@
         </LinearLayout>
 
         <LinearLayout
-            android:id="@+id/linearLayout2"
+            android:id="@+id/fragmentNavButtonsHLL"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:orientation="horizontal"

--- a/CMPUT_301_Project/app/src/main/res/layout/fragment_sign_up.xml
+++ b/CMPUT_301_Project/app/src/main/res/layout/fragment_sign_up.xml
@@ -109,12 +109,11 @@
                 android:layout_marginTop="32dp"
                 android:orientation="horizontal">
 
-                <!-- TODO: needs to be in line with other field TV's -->
                 <TextView
                     android:id="@+id/reenterPasswordTV"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
+                    android:layout_weight="100"
                     android:lines="2"
                     android:text="Re-Enter Password:"
                     android:textSize="24sp" />
@@ -123,7 +122,7 @@
                     android:id="@+id/reenterPasswordEV"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="30"
+                    android:layout_weight="1"
                     android:ems="10"
                     android:inputType="textPassword" />
             </LinearLayout>
@@ -139,7 +138,6 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent">
 
-            <!-- TODO: both buttons need functionality (skeleton func. = return to login page -->
             <Button
                 android:id="@+id/signUpButton"
                 android:layout_width="wrap_content"

--- a/CMPUT_301_Project/app/src/main/res/layout/fragment_sign_up.xml
+++ b/CMPUT_301_Project/app/src/main/res/layout/fragment_sign_up.xml
@@ -113,16 +113,16 @@
                     android:id="@+id/reenterPasswordTV"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="100"
+                    android:layout_weight="1"
                     android:lines="2"
                     android:text="Re-Enter Password:"
-                    android:textSize="24sp" />
+                    android:textSize="14sp" />
 
                 <EditText
                     android:id="@+id/reenterPasswordEV"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
+                    android:layout_weight="32"
                     android:ems="10"
                     android:inputType="textPassword" />
             </LinearLayout>

--- a/CMPUT_301_Project/app/src/main/res/layout/login_test.xml
+++ b/CMPUT_301_Project/app/src/main/res/layout/login_test.xml
@@ -41,4 +41,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="go to account" />
+
+    <Button
+        android:id="@+id/loginButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Go To Login" />
 </LinearLayout>


### PR DESCRIPTION
Basic UI page for user login along with the corresponding account creation fragment.

All buttons are functional for navigation to/from fragment and can be used to redirect to other pages as necessary.
Pressing the "sign-in" button currently does nothing, but function is present to allow for redirection to the main page.
Pressing the "Register" button will open the account creation fragment, which presents the user with all necessary text fields to create a new account. Both "Sign up" and "cancel" buttons in the fragment close the fragment, but can easily be changed to begin more complex tasks such as account creation.

The only UI element not present is the Logo on the main sign-in page to be added later.